### PR TITLE
fix: use node 18

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 18
       - name: Test and Build
         run: |
           yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 18
       - name: Test and Build
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ code in every repo that wants to check for cyclic dependencies.
 Install the package:
 
 ```
-yarn add @lifeomic/cyclone
+yarn add -D @lifeomic/cyclone
 ```
 
 Add a `cyclone.config.json` file to the root of the project with the following

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "cyclone": "cli.js"
   },
   "author": "LifeOmic <development@lifeomic.com>",
-  "license": "",
+  "license": "MIT",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Motivation

Moving GH action runners to node 18 + setting MIT license in package.json + updating readme.